### PR TITLE
added trigger error handling in MoodFormFragment (Story US 02.01.01)

### DIFF
--- a/code/app/src/androidTest/java/com/example/cmput301_team_project/ExampleInstrumentedTest.java
+++ b/code/app/src/androidTest/java/com/example/cmput301_team_project/ExampleInstrumentedTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 
 import static org.junit.Assert.*;
 
+
 /**
  * Instrumented test, which will execute on an Android device.
  *

--- a/code/app/src/main/java/com/example/cmput301_team_project/MoodFormFragment.java
+++ b/code/app/src/main/java/com/example/cmput301_team_project/MoodFormFragment.java
@@ -45,7 +45,9 @@ import java.util.Arrays;
  */
 public class MoodFormFragment extends DialogFragment {
     private final int MAX_IMAGE_SIZE = 65536;
-    private final int MAX_TRIGGER_LENGTH = 128;
+
+    private final int MAX_TRIGGER_LENGTH = 20;
+    private final int MAX_TRIGGER_WORDS = 3;
     interface MoodFormDialogListener {
         void addMood(Mood mood);
     }
@@ -115,8 +117,12 @@ public class MoodFormFragment extends DialogFragment {
                 // get the string input of trigger
                 String inputtedTrigger = trigger.getText().toString();
                 // invoke error if the length is less than max length
-                if (!isValidTrigger(inputtedTrigger)) {
-                    trigger.setError(String.format(getString(R.string.trigger_invalid_error_text), MAX_TRIGGER_LENGTH));
+                if (!isValidTriggerLength(inputtedTrigger)) {
+                    trigger.setError(String.format(getString(R.string.trigger_too_many_chars), MAX_TRIGGER_LENGTH));
+                    return;
+                }
+                if (!isValidTriggerWordCount(inputtedTrigger)) {
+                    trigger.setError(String.format(getString(R.string.trigger_too_many_words), MAX_TRIGGER_WORDS));
                     return;
                 }
                 Mood mood = Mood.createMood(MoodEmotionEnum.values()[emotion.getSelectedItemPosition()],
@@ -139,10 +145,20 @@ public class MoodFormFragment extends DialogFragment {
      * @param inputtedTrigger The trigger to be validated
      * @return {@code true} if the length of the trigger is less than {@code MAX_TRIGGER_LENGTH} otherwise {@code false}
      * */
-    private boolean isValidTrigger(String inputtedTrigger) {
-        return inputtedTrigger.length() < MAX_TRIGGER_LENGTH;
+    private boolean isValidTriggerLength(String inputtedTrigger) {
+        return inputtedTrigger.length() <= MAX_TRIGGER_LENGTH;
     }
-
+    /**
+     * Checks if the trigger text is of valid word count
+     *
+     * @param inputtedTrigger The trigger to be validated
+     * @return {@code true} if the length of the trigger is less than {@code MAX_TRIGGER_WORDS} otherwise {@code false}
+     * */
+    private boolean isValidTriggerWordCount(String inputtedTrigger) {
+        // splits the trigger string into a list of words (separated by whitespace)
+        String[] words = inputtedTrigger.trim().split("\\s+");
+        return words.length <= MAX_TRIGGER_WORDS;
+    }
     private void initializePhotoPicker(View view) {
         ImageView preview = view.findViewById(R.id.mood_image_preview);
         ImageButton removePreview = view.findViewById(R.id.remove_preview);

--- a/code/app/src/main/java/com/example/cmput301_team_project/MoodFormFragment.java
+++ b/code/app/src/main/java/com/example/cmput301_team_project/MoodFormFragment.java
@@ -45,7 +45,7 @@ import java.util.Arrays;
  */
 public class MoodFormFragment extends DialogFragment {
     private final int MAX_IMAGE_SIZE = 65536;
-
+    private final int MAX_TRIGGER_LENGTH = 128;
     interface MoodFormDialogListener {
         void addMood(Mood mood);
     }
@@ -112,10 +112,16 @@ public class MoodFormFragment extends DialogFragment {
                     emotionAdapter.setError(emotion.getSelectedView(), getString(R.string.no_emotional_state_error_msg));
                     return;
                 }
-
+                // get the string input of trigger
+                String inputtedTrigger = trigger.getText().toString();
+                // invoke error if the length is less than max length
+                if (!isValidTrigger(inputtedTrigger)) {
+                    trigger.setError(String.format(getString(R.string.trigger_invalid_error_text), MAX_TRIGGER_LENGTH));
+                    return;
+                }
                 Mood mood = Mood.createMood(MoodEmotionEnum.values()[emotion.getSelectedItemPosition()],
                         MoodSocialSituationEnum.values()[socialSituation.getSelectedItemPosition()],
-                        trigger.getText().toString(),
+                        inputtedTrigger,
                         SessionManager.getInstance().getCurrentUser(),
                         null,
                         imageViewToBase64(view.findViewById(R.id.mood_image_preview)));
@@ -126,6 +132,15 @@ public class MoodFormFragment extends DialogFragment {
         });
 
         return dialog;
+    }
+    /**
+     * Checks if the trigger text is of valid length
+     *
+     * @param inputtedTrigger The trigger to be validated
+     * @return {@code true} if the length of the trigger is less than {@code MAX_TRIGGER_LENGTH} otherwise {@code false}
+     * */
+    private boolean isValidTrigger(String inputtedTrigger) {
+        return inputtedTrigger.length() < MAX_TRIGGER_LENGTH;
     }
 
     private void initializePhotoPicker(View view) {

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -29,4 +29,5 @@
     <string name="remove_image">Remove Image</string>
     <string name="image_size_exceeded">Image exceeds the size limit of 64KB</string>
     <string name="image_invalid">Invalid image. Please try again</string>
+    <string name="trigger_invalid_error_text">Trigger must be under %d characters</string>
 </resources>

--- a/code/app/src/main/res/values/strings.xml
+++ b/code/app/src/main/res/values/strings.xml
@@ -29,5 +29,6 @@
     <string name="remove_image">Remove Image</string>
     <string name="image_size_exceeded">Image exceeds the size limit of 64KB</string>
     <string name="image_invalid">Invalid image. Please try again</string>
-    <string name="trigger_invalid_error_text">Trigger must be under %d characters</string>
+    <string name="trigger_too_many_chars">Trigger must be under %d characters</string>
+    <string name="trigger_too_many_words">Trigger must have at most %d words</string>
 </resources>

--- a/code/app/src/test/java/com/example/cmput301_team_project/ExampleUnitTest.java
+++ b/code/app/src/test/java/com/example/cmput301_team_project/ExampleUnitTest.java
@@ -1,7 +1,6 @@
 package com.example.cmput301_team_project;
 
 import org.junit.Test;
-
 import static org.junit.Assert.*;
 
 /**
@@ -13,5 +12,10 @@ public class ExampleUnitTest {
     @Test
     public void addition_isCorrect() {
         assertEquals(4, 2 + 2);
+    }
+
+    @Test
+    public void isValidTriggerWorks() {
+
     }
 }


### PR DESCRIPTION
- Added an error for the character limit on the "trigger" string in the mood class
- When a user makes a post, they can only type up to 127 characters 
      -  can be changed via MAX_TRIGGER_LENGTH in MoodFormFragment