### PR TITLE
Added Mac build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@
 # Virtual machine crash logs
 **/hs_err_pid*
 **/replay_pid*
+
+# Mac build files
+**/.DS_Store


### PR DESCRIPTION
- When running the app on Mac, it makes .DS_Store build files, which aren't needed.
- This now makes it easier to commit on my macbook.
